### PR TITLE
remove unnecessary error return type after using log.Fatalf()

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"log"
 	"os"
 
 	// application
@@ -14,15 +13,10 @@ import (
 )
 
 func main() {
-	var err error
-
 	dbaseDriver := os.Getenv("DB_DRIVER")
 	dsourceName := os.Getenv("DS_NAME")
 
-	dbAdapter, err := db.NewAdapter(dbaseDriver, dsourceName)
-	if err != nil {
-		log.Fatalf("failed to initiate dbase connection: %v", err)
-	}
+	dbAdapter := db.NewAdapter(dbaseDriver, dsourceName)
 	defer dbAdapter.CloseDbConnection()
 
 	// core

--- a/internal/adapters/framework/left/grpc/rpc_test.go
+++ b/internal/adapters/framework/left/grpc/rpc_test.go
@@ -26,17 +26,13 @@ const bufSize = 1024 * 1024
 var lis *bufconn.Listener
 
 func init() {
-	var err error
 	lis = bufconn.Listen(bufSize)
 	grpcServer := grpc.NewServer()
 
 	dbaseDriver := os.Getenv("DB_DRIVER")
 	dsourceName := os.Getenv("DS_NAME")
 
-	dbAdapter, err := db.NewAdapter(dbaseDriver, dsourceName)
-	if err != nil {
-		log.Fatalf("failed to initiate dbase connection: %v", err)
-	}
+	dbAdapter := db.NewAdapter(dbaseDriver, dsourceName)
 
 	// core
 	core := arithmetic.New()

--- a/internal/adapters/framework/right/db/db.go
+++ b/internal/adapters/framework/right/db/db.go
@@ -16,7 +16,7 @@ type Adapter struct {
 }
 
 // NewAdapter creates a new Adapter
-func NewAdapter(driverName, dataSourceName string) (*Adapter, error) {
+func NewAdapter(driverName, dataSourceName string) *Adapter {
 	// connect
 	db, err := sql.Open(driverName, dataSourceName)
 	if err != nil {
@@ -29,7 +29,7 @@ func NewAdapter(driverName, dataSourceName string) (*Adapter, error) {
 		log.Fatalf("db ping failure: %v", err)
 	}
 
-	return &Adapter{db: db}, nil
+	return &Adapter{db: db}
 }
 
 // CloseDbConnection closes the db  connection


### PR DESCRIPTION
NewAdapter(driverName, dataSourceName string) function has only one return statement located at the end of the body, it always returns `nil` for error, and two error cases were covered by calling `log.Fatalf()` so we can remove the error type from the method signature along with the places we call NewAdapter() method as a small clean up.